### PR TITLE
Add joke.py: Random Joke Generator (Closes #2)

### DIFF
--- a/joke.py
+++ b/joke.py
@@ -1,0 +1,20 @@
+import requests
+
+def get_joke():
+    url = "https://v2.jokeapi.dev/joke/Any"
+    try:
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+        data = response.json()
+
+        if data.get("type") == "single":
+            return data.get("joke")
+        elif data.get("type") == "twopart":
+            return f"{data.get('setup')} - {data.get('delivery')}"
+        else:
+            return "No joke found right now!"
+    except Exception as e:
+        return f"Error: {e}"
+
+if __name__ == "__main__":
+    print(get_joke())


### PR DESCRIPTION
Fixes #2

**Added `joke.py` with Random Joke Fetching Functionality**

- Created a new `joke.py` file that defines a `get_joke()` function to fetch random jokes from the [JokeAPI](https://v2.jokeapi.dev).
- Supports both single-line and two-part (setup + delivery) jokes, with appropriate formatting for each.
- Includes error handling for failed API requests (e.g., network issues or invalid responses).
- Can be run directly from the command line using `python joke.py` to display a random joke.
- Requires the `requests` library (`pip install requests`) for API calls.

Attached a screenshot showing the script’s output in the terminal:

![Screenshot of joke.py output in terminal](https://github.com/user-attachments/assets/f653e0a2-ae48-4153-b71a-508130b62077)

**Usage**:
```bash
pip install requests
python joke.py