### PR TITLE
feat(pirate): add Pirate Talk Translator + CLI and docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,14 @@ Thank you to all the amazing people who have contributed to this project! 🎉
 - **GitHub:** [@akadeepesh](https://github.com/akadeepesh)
 - **Contribution:** Random Quote Generator
 
+
+### Sujal Thakur
+
+- **Location:** Pune, India
+- **GitHub:** [@techbro815](https://github.com/techbro815)
+- **Contribution:** Pirate Talk Translator (English → pirate-style text with CLI)
+
+
 ---
 
 ## How to Add Yourself

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 - Fun **Mad Libs-style story generation**
 - Generate **themed haikus** with user-selected themes like nature, love, and season
 - Open for **contributions** and new features
+- Translate normal English into **pirate-style** phrases
+
+
 
 ---
 

--- a/pirate_translator.py
+++ b/pirate_translator.py
@@ -1,0 +1,98 @@
+"""
+this script converts normal english text into pirate-style english
+"""
+
+import re
+import sys
+from typing import Dict
+
+# word mapping
+word_map: Dict[str, str] = {
+    "hello": "ahoy",
+    "hi": "yo-ho-ho",
+    "my": "me",
+    "friend": "matey",
+    "friends": "mateys",
+    "is": "be",
+    "are": "be",
+    "the": "th’",
+    "you": "ye",
+    "your": "yer",
+    "sir": "cap’n",
+    "madam": "proud lady",
+    "where": "whar",
+    "stop": "avast",
+    "yes": "aye",
+    "no": "nay",
+    "money": "booty",
+    "treasure": "booty",
+    "left": "port",
+    "right": "starboard",
+    "old": "barnacle-covered",
+    "to": "t’",
+    "island": "isle",
+}
+
+# extra pirate words
+interjections = ("Arr!", "Yarr!", "Argh!", "Aye!")
+
+
+def preserve_case(src: str, dst: str) -> str:
+    # match the word case
+    if src.isupper():
+        return dst.upper()
+    if src[0].isupper():
+        return dst.capitalize()
+    return dst
+
+
+def replace_words(text: str, mapping: Dict[str, str]) -> str:
+    # replace full words only
+    def repl(m: re.Match) -> str:
+        word = m.group(0)
+        low = word.lower()
+        if low in mapping:
+            return preserve_case(word, mapping[low])
+        return word
+    return re.sub(r"\b[\w']+\b", repl, text)
+
+
+def decorate(text: str) -> str:
+    # add pirate touch after first sentence or exclamation
+    parts = re.split(r"(\.|\?|!)", text)
+    out = []
+    idx = 0
+    sent = 0
+
+    for i in range(0, len(parts), 2):
+        chunk = parts[i]
+        punc = parts[i + 1] if i + 1 < len(parts) else ""
+        piece = chunk + punc
+        if punc in {".", "!"}:
+            interj = interjections[idx % len(interjections)]
+            if punc == "!" or sent == 0:
+                piece = chunk.strip() + punc + " " + interj
+                idx += 1
+            sent += 1
+        out.append(piece)
+    return "".join(out)
+
+
+def to_pirate(text: str) -> str:
+    # main function
+    text = replace_words(text, word_map)
+    text = decorate(text)
+    return text
+
+
+def cli():
+    # simple cli
+    if len(sys.argv) < 2:
+        print('usage: python3 DSA/utils/pirate_translator.py "your text here"')
+        sys.exit(1)
+    print(to_pirate(" ".join(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    cli()
+


### PR DESCRIPTION
This PR adds a new Pirate Talk Translator feature to py-libs, implementing issue #25.
It converts normal English sentences into fun pirate-style phrases.


Example Output :

$ python3 pirate_translator.py "Hello friend, where is the treasure?"
Ahoy matey, whar be th’ booty? Arr!

$ python3 pirate_translator.py "Hi my friends! Stop there!"
Yo-ho-ho me mateys! Arr! Avast there! Yarr!

(Screenshot attached below for clarity)
<img width="1000" height="196" alt="Screenshot 2025-10-01 at 9 34 13 PM" src="https://github.com/user-attachments/assets/9605f35d-51c0-407d-bff7-4f324a35605c" />

